### PR TITLE
bump ndarray version to 0.14

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/paulkernfeld/ndarray-csv"
 [dependencies]
 csv = "1"
 either = "1"
-ndarray = "0.13"
+ndarray = "0.14"
 serde = "1"
 
 [dev-dependencies]


### PR DESCRIPTION
Hello!

I was using this package but then needed some features from ndarray 0.14 and I've checked and all tests seem to pass fine with ndarray 0.14.

Thanks!