### PR TITLE
Update ndarray to 0.15

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/paulkernfeld/ndarray-csv"
 [dependencies]
 csv = "1"
 either = "1"
-ndarray = "0.14"
+ndarray = "0.15"
 serde = "1"
 
 [dev-dependencies]


### PR DESCRIPTION
Updates `ndarray` dependency to current `0.15`.